### PR TITLE
Add conditional compilation for optional dependencies

### DIFF
--- a/lib/ecto/translatable_fields.ex
+++ b/lib/ecto/translatable_fields.ex
@@ -1,171 +1,173 @@
-defmodule I18nHelpers.Ecto.TranslatableFields do
-  @moduledoc ~S"""
-  Provides macros for defining translatable fields and associations.
+if Code.ensure_loaded?(Ecto) do
+  defmodule I18nHelpers.Ecto.TranslatableFields do
+    @moduledoc ~S"""
+    Provides macros for defining translatable fields and associations.
 
-  This module's purpose is to provide the `I18nHelpers.Ecto.Translator` module
-  with a way to access the list of fields and associations from the Ecto Schema
-  that needs to be translated, and with virtual fields allowing to store the
-  translations for the current locale.
+    This module's purpose is to provide the `I18nHelpers.Ecto.Translator` module
+    with a way to access the list of fields and associations from the Ecto Schema
+    that needs to be translated, and with virtual fields allowing to store the
+    translations for the current locale.
 
-  `__using__\1` this module provides the caller module with two functions:
-  `get_translatable_fields\0` and `get_translatable_assocs\0` listing all the
-  translatable fields and the translatable associations respectively.
+    `__using__\1` this module provides the caller module with two functions:
+    `get_translatable_fields\0` and `get_translatable_assocs\0` listing all the
+    translatable fields and the translatable associations respectively.
 
-  Fields that are to be translated are expected to hold maps
+    Fields that are to be translated are expected to hold maps
 
-      field :title, :map
+        field :title, :map
 
-  where each key represents a locale and each value contains the text for
-  that locale. Below is an example of such map:
+    where each key represents a locale and each value contains the text for
+    that locale. Below is an example of such map:
 
-      %{
-        "en" => "My Favorite Books",
-        "fr" => "Mes Livres Préférés",
-        "nl" => "Mijn Lievelingsboeken",
-        "en-GB" => "My Favourite Books"
-      }
+        %{
+          "en" => "My Favorite Books",
+          "fr" => "Mes Livres Préférés",
+          "nl" => "Mijn Lievelingsboeken",
+          "en-GB" => "My Favourite Books"
+        }
 
-  Each of those fields must come with a virtual field which is used to
-  hold the translation for the current locale.
+    Each of those fields must come with a virtual field which is used to
+    hold the translation for the current locale.
 
-      field :title, :map
-      field :translated_title, :string, virtual: true
+        field :title, :map
+        field :translated_title, :string, virtual: true
 
-  Such a translatable field must be included in the translatable fields list:
+    Such a translatable field must be included in the translatable fields list:
 
-      def get_translatable_fields, do: [:title]
+        def get_translatable_fields, do: [:title]
 
-  This module provides the macro `translatable_field\1` which allows to execute
-  those three steps above (add the field as `:map`, add the virtual field and
-  add the field to the translatable fields list) in one line:
+    This module provides the macro `translatable_field\1` which allows to execute
+    those three steps above (add the field as `:map`, add the virtual field and
+    add the field to the translatable fields list) in one line:
 
-      translatable_field :title
+        translatable_field :title
 
-  Macros marking associations as translatable are also provided:
+    Macros marking associations as translatable are also provided:
 
-    * translatable_belongs_to\2
-    * translatable_has_many\2
-    * translatable_has_one\2
-    * translatable_many_to_many\3
+      * translatable_belongs_to\2
+      * translatable_has_many\2
+      * translatable_has_one\2
+      * translatable_many_to_many\3
 
-  The macros above add the given association field name to the translatable
-  associations list, which is accessible with `get_translatable_assocs\0`.
-  """
+    The macros above add the given association field name to the translatable
+    associations list, which is accessible with `get_translatable_assocs\0`.
+    """
 
-  alias I18nHelpers.Ecto.TranslatableType
+    alias I18nHelpers.Ecto.TranslatableType
 
-  @callback get_translatable_fields() :: [atom]
-  @callback get_translatable_assocs() :: [atom]
+    @callback get_translatable_fields() :: [atom]
+    @callback get_translatable_assocs() :: [atom]
 
-  defmacro __using__(_args) do
-    this_module = __MODULE__
+    defmacro __using__(_args) do
+      this_module = __MODULE__
 
-    quote do
-      @behaviour unquote(this_module)
+      quote do
+        @behaviour unquote(this_module)
 
-      import unquote(this_module),
-        only: [
-          translatable_field: 1,
-          translatable_belongs_to: 2,
-          translatable_has_many: 2,
-          translatable_has_one: 2,
-          translatable_many_to_many: 3
-        ]
+        import unquote(this_module),
+          only: [
+            translatable_field: 1,
+            translatable_belongs_to: 2,
+            translatable_has_many: 2,
+            translatable_has_one: 2,
+            translatable_many_to_many: 3
+          ]
 
-      Module.register_attribute(__MODULE__, :translatable_fields, accumulate: true)
-      Module.register_attribute(__MODULE__, :translatable_assocs, accumulate: true)
+        Module.register_attribute(__MODULE__, :translatable_fields, accumulate: true)
+        Module.register_attribute(__MODULE__, :translatable_assocs, accumulate: true)
 
-      @before_compile unquote(this_module)
+        @before_compile unquote(this_module)
+      end
     end
-  end
 
-  defmacro __before_compile__(_env) do
-    quote do
-      def get_translatable_fields(), do: @translatable_fields
-      def get_translatable_assocs(), do: @translatable_assocs
+    defmacro __before_compile__(_env) do
+      quote do
+        def get_translatable_fields(), do: @translatable_fields
+        def get_translatable_assocs(), do: @translatable_assocs
+      end
     end
-  end
 
-  @doc ~S"""
-  Defines a translatable field on the schema.
+    @doc ~S"""
+    Defines a translatable field on the schema.
 
-  This macro will generate two fields:
+    This macro will generate two fields:
 
-    * a field with the given name and type `:map` and
-    * a virtual field with the given name prepended by `"translated_"` and type `:string`.
+      * a field with the given name and type `:map` and
+      * a virtual field with the given name prepended by `"translated_"` and type `:string`.
 
-  For example
+    For example
 
-      translatable_field :title
+        translatable_field :title
 
-  will generate
+    will generate
 
-      field :title, :map
-      field :translated_title, :string, virtual: true
+        field :title, :map
+        field :translated_title, :string, virtual: true
 
-  The macro will add the given field name into the translatable fields list.
-  """
-  defmacro translatable_field(field_name) do
-    quote do
-      field(unquote(field_name), TranslatableType)
+    The macro will add the given field name into the translatable fields list.
+    """
+    defmacro translatable_field(field_name) do
+      quote do
+        field(unquote(field_name), TranslatableType)
 
-      field(String.to_atom("translated_" <> Atom.to_string(unquote(field_name))), :string,
-        virtual: true
-      )
+        field(String.to_atom("translated_" <> Atom.to_string(unquote(field_name))), :string,
+          virtual: true
+        )
 
-      Module.put_attribute(__MODULE__, :translatable_fields, unquote(field_name))
+        Module.put_attribute(__MODULE__, :translatable_fields, unquote(field_name))
+      end
     end
-  end
 
-  @doc ~S"""
-  Defines a translatable `belongs_to` association.
+    @doc ~S"""
+    Defines a translatable `belongs_to` association.
 
-  The macro will add the given field name into the translatable associations list.
-  """
-  defmacro translatable_belongs_to(field_name, module_name) do
-    quote do
-      belongs_to(unquote(field_name), unquote(module_name))
+    The macro will add the given field name into the translatable associations list.
+    """
+    defmacro translatable_belongs_to(field_name, module_name) do
+      quote do
+        belongs_to(unquote(field_name), unquote(module_name))
 
-      Module.put_attribute(__MODULE__, :translatable_assocs, unquote(field_name))
+        Module.put_attribute(__MODULE__, :translatable_assocs, unquote(field_name))
+      end
     end
-  end
 
-  @doc ~S"""
-  Defines a translatable `has_many` association.
+    @doc ~S"""
+    Defines a translatable `has_many` association.
 
-  The macro will add the given field name into the translatable associations list.
-  """
-  defmacro translatable_has_many(field_name, module_name) do
-    quote do
-      has_many(unquote(field_name), unquote(module_name))
+    The macro will add the given field name into the translatable associations list.
+    """
+    defmacro translatable_has_many(field_name, module_name) do
+      quote do
+        has_many(unquote(field_name), unquote(module_name))
 
-      Module.put_attribute(__MODULE__, :translatable_assocs, unquote(field_name))
+        Module.put_attribute(__MODULE__, :translatable_assocs, unquote(field_name))
+      end
     end
-  end
 
-  @doc ~S"""
-  Defines a translatable `has_one` association.
+    @doc ~S"""
+    Defines a translatable `has_one` association.
 
-  The macro will add the given field name into the translatable associations list.
-  """
-  defmacro translatable_has_one(field_name, module_name) do
-    quote do
-      has_one(unquote(field_name), unquote(module_name))
+    The macro will add the given field name into the translatable associations list.
+    """
+    defmacro translatable_has_one(field_name, module_name) do
+      quote do
+        has_one(unquote(field_name), unquote(module_name))
 
-      Module.put_attribute(__MODULE__, :translatable_assocs, unquote(field_name))
+        Module.put_attribute(__MODULE__, :translatable_assocs, unquote(field_name))
+      end
     end
-  end
 
-  @doc ~S"""
-  Defines a translatable `many_to_many` association.
+    @doc ~S"""
+    Defines a translatable `many_to_many` association.
 
-  The macro will add the given field name into the translatable associations list.
-  """
-  defmacro translatable_many_to_many(field_name, module_name, opts \\ []) do
-    quote do
-      many_to_many(unquote(field_name), unquote(module_name), unquote(opts))
+    The macro will add the given field name into the translatable associations list.
+    """
+    defmacro translatable_many_to_many(field_name, module_name, opts \\ []) do
+      quote do
+        many_to_many(unquote(field_name), unquote(module_name), unquote(opts))
 
-      Module.put_attribute(__MODULE__, :translatable_assocs, unquote(field_name))
+        Module.put_attribute(__MODULE__, :translatable_assocs, unquote(field_name))
+      end
     end
   end
 end

--- a/lib/ecto/translatable_type.ex
+++ b/lib/ecto/translatable_type.ex
@@ -1,32 +1,34 @@
-defmodule I18nHelpers.Ecto.TranslatableType do
-  use Ecto.Type
+if Code.ensure_loaded?(Ecto) do
+  defmodule I18nHelpers.Ecto.TranslatableType do
+    use Ecto.Type
 
-  # data type we want to use to store our custom value at the database level
-  def type, do: :map
+    # data type we want to use to store our custom value at the database level
+    def type, do: :map
 
-  # takes a value from an external source (for example a user input) and
-  # converts it into a format that Ecto can work with
-  def cast(translations) when translations == %{}, do: {:ok, nil}
+    # takes a value from an external source (for example a user input) and
+    # converts it into a format that Ecto can work with
+    def cast(translations) when translations == %{}, do: {:ok, nil}
 
-  def cast(%{} = translations) do
-    translations_without_empty =
-      translations
-      |> Enum.reject(fn {_, v} -> String.trim(v) == "" end)
-      |> Map.new()
-      |> (fn
-            map when map == %{} -> nil
-            map -> map
-          end).()
+    def cast(%{} = translations) do
+      translations_without_empty =
+        translations
+        |> Enum.reject(fn {_, v} -> String.trim(v) == "" end)
+        |> Map.new()
+        |> (fn
+              map when map == %{} -> nil
+              map -> map
+            end).()
 
-    {:ok, translations_without_empty}
+      {:ok, translations_without_empty}
+    end
+
+    def cast(nil), do: {:ok, nil}
+    def cast(_), do: :error
+
+    # converts the raw value pulled from the database into an Elixir value
+    def load(term), do: Ecto.Type.load(:map, term)
+
+    # takes an Elixir value and converts it into a value that the database recognizes
+    def dump(term), do: Ecto.Type.dump(:map, term)
   end
-
-  def cast(nil), do: {:ok, nil}
-  def cast(_), do: :error
-
-  # converts the raw value pulled from the database into an Elixir value
-  def load(term), do: Ecto.Type.load(:map, term)
-
-  # takes an Elixir value and converts it into a value that the database recognizes
-  def dump(term), do: Ecto.Type.dump(:map, term)
 end

--- a/lib/ecto/translator.ex
+++ b/lib/ecto/translator.ex
@@ -1,156 +1,156 @@
-defmodule I18nHelpers.Ecto.Translator do
-  @doc ~S"""
-  Translates an Ecto struct, a list of Ecto structs or a map containing translations.
+if Code.ensure_loaded?(Ecto) do
+  defmodule I18nHelpers.Ecto.Translator do
+    @doc ~S"""
+    Translates an Ecto struct, a list of Ecto structs or a map containing translations.
 
-  Translating an Ecto struct for a given locale consists of the following steps:
+    Translating an Ecto struct for a given locale consists of the following steps:
 
-    1. Get the list of the fields that need to be translated from the Schema.
-       The Schema must contain a `get_translatable_fields\0` function returning
-       a list of those fields.
+      1. Get the list of the fields that need to be translated from the Schema.
+         The Schema must contain a `get_translatable_fields\0` function returning
+         a list of those fields.
 
-    2. Get the text for the given locale and store it into a virtual field.
-       The Schema must provide, for each translatable field, a corresponding
-       virtual field in order to store the translation.
+      2. Get the text for the given locale and store it into a virtual field.
+         The Schema must provide, for each translatable field, a corresponding
+         virtual field in order to store the translation.
 
-    3. Get the list of the associations that also need to be translated from
-       the Schema. The Schema must contain a `get_translatable_assocs\0` function
-       returning a list of those associations.
+      3. Get the list of the associations that also need to be translated from
+         the Schema. The Schema must contain a `get_translatable_assocs\0` function
+         returning a list of those associations.
 
-    4. Repeat step 1. for each associated Ecto struct.
-  """
-  @spec translate(list | struct | map, String.t() | atom, keyword) ::
-          list | struct | String.t()
-  def translate(data_structure, locale \\ Gettext.get_locale(), opts \\ [])
+      4. Repeat step 1. for each associated Ecto struct.
+    """
+    @spec translate(list | struct | map, String.t() | atom, keyword) ::
+            list | struct | String.t()
+    def translate(data_structure, locale \\ Gettext.get_locale(), opts \\ [])
 
-  def translate([], _locale, _opts), do: []
+    def translate([], _locale, _opts), do: []
 
-  def translate([head | tail], locale, opts) do
-    [
-      translate(head, locale, opts)
-      | translate(tail, locale, opts)
-    ]
-  end
-
-  def translate(%{__struct__: _struct_name} = struct, locale, opts) do
-    translate_struct(struct, locale, opts)
-  end
-
-  def translate(%{} = map, locale, opts) do
-    translate_map(map, locale, opts)
-  end
-
-  def translate(nil, locale, opts) do
-    translate_map(%{}, locale, opts)
-  end
-
-  defp translate_struct(%{__struct__: _struct_name} = entity, locale, opts) do
-    fields_to_translate = entity.__struct__.get_translatable_fields()
-    assocs_to_translate = entity.__struct__.get_translatable_assocs()
-
-    entity =
-      Enum.reduce(fields_to_translate, entity, fn field, updated_entity ->
-        virtual_translated_field = String.to_atom("translated_" <> Atom.to_string(field))
-
-        %{^field => translations} = entity
-
-        handle_missing_translation = fn translations_map, locale ->
-          Keyword.get(opts, :handle_missing_field_translation, fn _, _, _ -> true end)
-          |> apply([field, translations_map, locale])
-
-          Keyword.get(opts, :handle_missing_translation, fn _, _ -> true end)
-          |> apply([translations_map, locale])
-        end
-
-        opts = Keyword.put(opts, :handle_missing_translation, handle_missing_translation)
-
-        struct(updated_entity, [
-          {virtual_translated_field, translate(translations, locale, opts)}
-        ])
-      end)
-
-    entity =
-      Enum.reduce(assocs_to_translate, entity, fn field, updated_entity ->
-        %{^field => assoc} = entity
-
-        case Ecto.assoc_loaded?(assoc) do
-          true ->
-            struct(updated_entity, [{field, translate(assoc, locale, opts)}])
-
-          _ ->
-            updated_entity
-        end
-      end)
-
-    entity
-  end
-
-  defp translate_map(%{} = translations_map, locale, opts) do
-    locale = to_string(locale)
-
-    fallback_locale =
-      Keyword.get(opts, :fallback_locale, Gettext.get_locale())
-      |> to_string()
-
-    handle_missing_translation =
-      Keyword.get(opts, :handle_missing_translation, fn _, _ -> true end)
-
-    cond do
-      has_translation?(translations_map, locale) ->
-        translations_map[locale]
-
-      has_translation?(translations_map, fallback_locale) ->
-        translation = translations_map[fallback_locale]
-        handle_missing_translation.(translations_map, locale)
-        translation
-
-      true ->
-        handle_missing_translation.(translations_map, locale)
-        ""
-    end
-  end
-
-  @doc ~S"""
-  Same as `translate/3` but raises an error if a translation is missing.
-  """
-  @spec translate!(list | struct | map, String.t() | atom, keyword) ::
-          list | struct | String.t()
-  def translate!(data_structure, locale \\ Gettext.get_locale(), opts \\ []) do
-    handle_missing_field_translation = fn field, translations_map, locale ->
-      Keyword.get(opts, :handle_missing_field_translation, fn _, _, _ -> true end)
-      |> apply([field, translations_map, locale])
-
-      raise "translation of field #{inspect(field)} for locale \"#{locale}\" not found in map #{
-              inspect(translations_map)
-            }"
+    def translate([head | tail], locale, opts) do
+      [
+        translate(head, locale, opts)
+        | translate(tail, locale, opts)
+      ]
     end
 
-    handle_missing_translation = fn translations_map, locale ->
-      Keyword.get(opts, :handle_missing_translation, fn _, _ -> true end)
-      |> apply([translations_map, locale])
-
-      raise "translation for locale \"#{locale}\" not found in map #{inspect(translations_map)}"
+    def translate(%{__struct__: _struct_name} = struct, locale, opts) do
+      translate_struct(struct, locale, opts)
     end
 
-    opts =
-      opts
-      |> Keyword.put(:handle_missing_field_translation, handle_missing_field_translation)
-      |> Keyword.put(:handle_missing_translation, handle_missing_translation)
+    def translate(%{} = map, locale, opts) do
+      translate_map(map, locale, opts)
+    end
 
-    translate(data_structure, locale, opts)
-  end
+    def translate(nil, locale, opts) do
+      translate_map(%{}, locale, opts)
+    end
 
-  defp has_translation?(translations_map, locale),
-    do: Map.has_key?(translations_map, locale) && String.trim(locale) != ""
+    defp translate_struct(%{__struct__: _struct_name} = entity, locale, opts) do
+      fields_to_translate = entity.__struct__.get_translatable_fields()
+      assocs_to_translate = entity.__struct__.get_translatable_assocs()
 
-  # @doc ~S"""
-  # Returns a closure allowing to memorize the given options for `translate\3`.
-  # """
-  def set_opts(opts) do
-    fn data_structure, overriding_opts ->
-      opts = Keyword.merge(opts, overriding_opts)
-      locale = Keyword.get(opts, :locale, Gettext.get_locale())
+      entity =
+        Enum.reduce(fields_to_translate, entity, fn field, updated_entity ->
+          virtual_translated_field = String.to_atom("translated_" <> Atom.to_string(field))
+
+          %{^field => translations} = entity
+
+          handle_missing_translation = fn translations_map, locale ->
+            Keyword.get(opts, :handle_missing_field_translation, fn _, _, _ -> true end)
+            |> apply([field, translations_map, locale])
+
+            Keyword.get(opts, :handle_missing_translation, fn _, _ -> true end)
+            |> apply([translations_map, locale])
+          end
+
+          opts = Keyword.put(opts, :handle_missing_translation, handle_missing_translation)
+
+          struct(updated_entity, [
+            {virtual_translated_field, translate(translations, locale, opts)}
+          ])
+        end)
+
+      entity =
+        Enum.reduce(assocs_to_translate, entity, fn field, updated_entity ->
+          %{^field => assoc} = entity
+
+          case Ecto.assoc_loaded?(assoc) do
+            true ->
+              struct(updated_entity, [{field, translate(assoc, locale, opts)}])
+
+            _ ->
+              updated_entity
+          end
+        end)
+
+      entity
+    end
+
+    defp translate_map(%{} = translations_map, locale, opts) do
+      locale = to_string(locale)
+
+      fallback_locale =
+        Keyword.get(opts, :fallback_locale, Gettext.get_locale())
+        |> to_string()
+
+      handle_missing_translation =
+        Keyword.get(opts, :handle_missing_translation, fn _, _ -> true end)
+
+      cond do
+        has_translation?(translations_map, locale) ->
+          translations_map[locale]
+
+        has_translation?(translations_map, fallback_locale) ->
+          translation = translations_map[fallback_locale]
+          handle_missing_translation.(translations_map, locale)
+          translation
+
+        true ->
+          handle_missing_translation.(translations_map, locale)
+          ""
+      end
+    end
+
+    @doc ~S"""
+    Same as `translate/3` but raises an error if a translation is missing.
+    """
+    @spec translate!(list | struct | map, String.t() | atom, keyword) ::
+            list | struct | String.t()
+    def translate!(data_structure, locale \\ Gettext.get_locale(), opts \\ []) do
+      handle_missing_field_translation = fn field, translations_map, locale ->
+        Keyword.get(opts, :handle_missing_field_translation, fn _, _, _ -> true end)
+        |> apply([field, translations_map, locale])
+
+        raise "translation of field #{inspect(field)} for locale \"#{locale}\" not found in map #{inspect(translations_map)}"
+      end
+
+      handle_missing_translation = fn translations_map, locale ->
+        Keyword.get(opts, :handle_missing_translation, fn _, _ -> true end)
+        |> apply([translations_map, locale])
+
+        raise "translation for locale \"#{locale}\" not found in map #{inspect(translations_map)}"
+      end
+
+      opts =
+        opts
+        |> Keyword.put(:handle_missing_field_translation, handle_missing_field_translation)
+        |> Keyword.put(:handle_missing_translation, handle_missing_translation)
 
       translate(data_structure, locale, opts)
+    end
+
+    defp has_translation?(translations_map, locale),
+      do: Map.has_key?(translations_map, locale) && String.trim(locale) != ""
+
+    # @doc ~S"""
+    # Returns a closure allowing to memorize the given options for `translate\3`.
+    # """
+    def set_opts(opts) do
+      fn data_structure, overriding_opts ->
+        opts = Keyword.merge(opts, overriding_opts)
+        locale = Keyword.get(opts, :locale, Gettext.get_locale())
+
+        translate(data_structure, locale, opts)
+      end
     end
   end
 end

--- a/lib/html/input_helpers.ex
+++ b/lib/html/input_helpers.ex
@@ -1,195 +1,198 @@
-defmodule I18nHelpers.HTML.InputHelpers do
-  @moduledoc ~S"""
-  Provides view helpers to render HTML input fields for text that must be
-  provided in multiple languages. The multilingual texts passed to the
-  form (usually in a changeset) are expected to be maps where each key
-  represents a locale and each value contains the text for that locale.
-  For example:
+if Code.ensure_loaded?(Phoenix.HTML) do
+  defmodule I18nHelpers.HTML.InputHelpers do
+    @moduledoc ~S"""
+    Provides view helpers to render HTML input fields for text that must be
+    provided in multiple languages. The multilingual texts passed to the
+    form (usually in a changeset) are expected to be maps where each key
+    represents a locale and each value contains the text for that locale.
+    For example:
 
-      %{
-        "en" => "hello world",
-        "fr" => "bonjour monde",
-        "nl" => "hallo wereld"
-      }
-  """
+        %{
+          "en" => "hello world",
+          "fr" => "bonjour monde",
+          "nl" => "hallo wereld"
+        }
+    """
 
-  alias Phoenix.HTML.Form
-  alias Phoenix.HTML.Tag
+    alias Phoenix.HTML.Form
+    alias Phoenix.HTML.Tag
 
-  @doc ~S"""
-  Renders a text input HTML element filled with the translated value for the
-  given locale.
+    @doc ~S"""
+    Renders a text input HTML element filled with the translated value for the
+    given locale.
 
-  Additional HTML attributes can be provided through opts argument.
-  """
-  def translated_text_input(form, field, locale, opts \\ []) do
-    opts = Keyword.put_new(opts, :name, translated_input_name(form, field, locale))
+    Additional HTML attributes can be provided through opts argument.
+    """
+    def translated_text_input(form, field, locale, opts \\ []) do
+      opts = Keyword.put_new(opts, :name, translated_input_name(form, field, locale))
 
-    translated_field(form, field, {:input, [type: "text"]}, locale, opts)
-  end
+      translated_field(form, field, {:input, [type: "text"]}, locale, opts)
+    end
 
-  @doc ~S"""
-  Renders a textarea input HTML element filled with the translated value for the
-  given locale.
+    @doc ~S"""
+    Renders a textarea input HTML element filled with the translated value for the
+    given locale.
 
-  Additional HTML attributes can be provided through opts argument.
-  """
-  def translated_textarea(form, field, locale, opts \\ []) do
-    opts = Keyword.put_new(opts, :name, translated_input_name(form, field, locale))
+    Additional HTML attributes can be provided through opts argument.
+    """
+    def translated_textarea(form, field, locale, opts \\ []) do
+      opts = Keyword.put_new(opts, :name, translated_input_name(form, field, locale))
 
-    translated_field(form, field, {:textarea, []}, locale, opts)
-  end
+      translated_field(form, field, {:textarea, []}, locale, opts)
+    end
 
-  @doc ~S"""
-  Renders a custom input HTML element filled with the translated value for the
-  given locale. The default element is `div` and may be changed through the `tag`
-  option.
+    @doc ~S"""
+    Renders a custom input HTML element filled with the translated value for the
+    given locale. The default element is `div` and may be changed through the `tag`
+    option.
 
-  Additional HTML attributes can be provided through opts argument.
-  """
-  def translated_element(form, field, locale, opts \\ []) do
-    {tag, opts} = Keyword.pop(opts, :tag, :div)
+    Additional HTML attributes can be provided through opts argument.
+    """
+    def translated_element(form, field, locale, opts \\ []) do
+      {tag, opts} = Keyword.pop(opts, :tag, :div)
 
-    translated_field(form, field, {tag, []}, locale, opts)
-  end
+      translated_field(form, field, {tag, []}, locale, opts)
+    end
 
-  defp translated_field(form, field, {tag, attrs}, locale, opts) do
-    locale = to_string(locale)
-
-    translations = Form.input_value(form, field) || %{}
-    translation = Map.get(translations, locale, "")
-
-    attrs =
-      [id: translated_input_id(form, field, locale)]
-      |> Keyword.merge(attrs)
-      |> Keyword.merge(opts)
-
-    tag(tag, translation, attrs)
-  end
-
-  @doc ~S"""
-  Renders multiple text input HTML elements for the given locales (one for each locale).
-
-  ## Options
-
-  The options allow providing additional HTML attributes, as well as:
-
-    * `:labels` - an anonymous function returning the label for each generated input;
-    the locale is given as argument
-    * `:wrappers` - an anonymous function returning a custom wrapper for each generated input;
-    the locale is given as argument
-
-  ## Example
-
-  ```
-  translated_text_inputs(f, :title, [:en, :fr],
-    labels: fn locale -> content_tag(:i, locale) end,
-    wrappers: fn _locale -> {:div, class: "translated-input-wrapper"} end
-  )
-  ```
-  """
-  def translated_text_inputs(form, field, locales_or_gettext_backend, opts \\ [])
-
-  def translated_text_inputs(form, field, gettext_backend, opts) when is_atom(gettext_backend) do
-    translated_text_inputs(form, field, Gettext.known_locales(gettext_backend), opts)
-  end
-
-  def translated_text_inputs(form, field, locales, opts) do
-    translated_fields(&translated_text_input/4, form, field, locales, opts)
-  end
-
-  @doc ~S"""
-  Renders multiple textarea HTML elements for the given locales (one for each locale).
-
-  For options, see `translated_text_inputs/4`
-  """
-  def translated_textareas(form, field, locales_or_gettext_backend, opts \\ [])
-
-  def translated_textareas(form, field, gettext_backend, opts) when is_atom(gettext_backend) do
-    translated_textareas(form, field, Gettext.known_locales(gettext_backend), opts)
-  end
-
-  def translated_textareas(form, field, locales, opts) do
-    translated_fields(&translated_textarea/4, form, field, locales, opts)
-  end
-
-  @doc ~S"""
-  Renders multiple custom HTML elements for the given locales (one for each locale).
-  The default element is `div` and may be changed through the `tag` option.
-
-  For options, see `translated_text_inputs/4`
-  """
-  def translated_elements(form, field, locales_or_gettext_backend, opts \\ [])
-
-  def translated_elements(form, field, gettext_backend, opts) when is_atom(gettext_backend) do
-    translated_elements(form, field, Gettext.known_locales(gettext_backend), opts)
-  end
-
-  def translated_elements(form, field, locales, opts) do
-    translated_fields(&translated_element/4, form, field, locales, opts)
-  end
-
-  defp translated_fields(fun, form, field, locales, opts) do
-    {get_label_data, opts} = Keyword.pop(opts, :labels, fn locale -> locale end)
-    {get_wrapper_data, opts} = Keyword.pop(opts, :wrappers, fn _locale -> nil end)
-
-    Enum.map(locales, fn locale ->
+    defp translated_field(form, field, {tag, attrs}, locale, opts) do
       locale = to_string(locale)
 
-      wrap(get_wrapper_data.(locale), fn ->
-        [
-          render_label(form, translated_label_for(field, locale), get_label_data.(locale)),
-          fun.(form, field, locale, opts)
-        ]
+      translations = Form.input_value(form, field) || %{}
+      translation = Map.get(translations, locale, "")
+
+      attrs =
+        [id: translated_input_id(form, field, locale)]
+        |> Keyword.merge(attrs)
+        |> Keyword.merge(opts)
+
+      tag(tag, translation, attrs)
+    end
+
+    @doc ~S"""
+    Renders multiple text input HTML elements for the given locales (one for each locale).
+
+    ## Options
+
+    The options allow providing additional HTML attributes, as well as:
+
+      * `:labels` - an anonymous function returning the label for each generated input;
+      the locale is given as argument
+      * `:wrappers` - an anonymous function returning a custom wrapper for each generated input;
+      the locale is given as argument
+
+    ## Example
+
+    ```
+    translated_text_inputs(f, :title, [:en, :fr],
+      labels: fn locale -> content_tag(:i, locale) end,
+      wrappers: fn _locale -> {:div, class: "translated-input-wrapper"} end
+    )
+    ```
+    """
+    def translated_text_inputs(form, field, locales_or_gettext_backend, opts \\ [])
+
+    def translated_text_inputs(form, field, gettext_backend, opts)
+        when is_atom(gettext_backend) do
+      translated_text_inputs(form, field, Gettext.known_locales(gettext_backend), opts)
+    end
+
+    def translated_text_inputs(form, field, locales, opts) do
+      translated_fields(&translated_text_input/4, form, field, locales, opts)
+    end
+
+    @doc ~S"""
+    Renders multiple textarea HTML elements for the given locales (one for each locale).
+
+    For options, see `translated_text_inputs/4`
+    """
+    def translated_textareas(form, field, locales_or_gettext_backend, opts \\ [])
+
+    def translated_textareas(form, field, gettext_backend, opts) when is_atom(gettext_backend) do
+      translated_textareas(form, field, Gettext.known_locales(gettext_backend), opts)
+    end
+
+    def translated_textareas(form, field, locales, opts) do
+      translated_fields(&translated_textarea/4, form, field, locales, opts)
+    end
+
+    @doc ~S"""
+    Renders multiple custom HTML elements for the given locales (one for each locale).
+    The default element is `div` and may be changed through the `tag` option.
+
+    For options, see `translated_text_inputs/4`
+    """
+    def translated_elements(form, field, locales_or_gettext_backend, opts \\ [])
+
+    def translated_elements(form, field, gettext_backend, opts) when is_atom(gettext_backend) do
+      translated_elements(form, field, Gettext.known_locales(gettext_backend), opts)
+    end
+
+    def translated_elements(form, field, locales, opts) do
+      translated_fields(&translated_element/4, form, field, locales, opts)
+    end
+
+    defp translated_fields(fun, form, field, locales, opts) do
+      {get_label_data, opts} = Keyword.pop(opts, :labels, fn locale -> locale end)
+      {get_wrapper_data, opts} = Keyword.pop(opts, :wrappers, fn _locale -> nil end)
+
+      Enum.map(locales, fn locale ->
+        locale = to_string(locale)
+
+        wrap(get_wrapper_data.(locale), fn ->
+          [
+            render_label(form, translated_label_for(field, locale), get_label_data.(locale)),
+            fun.(form, field, locale, opts)
+          ]
+        end)
       end)
-    end)
-  end
-
-  defp wrap(nil, render_content), do: render_content.()
-
-  defp wrap({tag, opts}, render_content) do
-    Tag.content_tag tag, opts do
-      render_content.()
     end
-  end
 
-  defp render_label(form, field, {{:safe, _} = label, opts}),
-       do: safe_render_label(form, field, label, opts)
+    defp wrap(nil, render_content), do: render_content.()
 
-  defp render_label(form, field, {:safe, _} = label),
-       do: safe_render_label(form, field, label, [])
-
-  defp render_label(form, field, {label, opts}),
-       do: safe_render_label(form, field, label, opts)
-
-  defp render_label(form, field, label),
-       do: safe_render_label(form, field, label, [])
-
-  defp safe_render_label(form, field, label, opts) do
-    Form.label form, field, opts do
-      label
+    defp wrap({tag, opts}, render_content) do
+      Tag.content_tag tag, opts do
+        render_content.()
+      end
     end
-  end
 
-  defp tag(:input = tag, content, attrs) do
-    attrs = Keyword.put_new(attrs, :value, content)
+    defp render_label(form, field, {{:safe, _} = label, opts}),
+      do: safe_render_label(form, field, label, opts)
 
-    Tag.tag(tag, attrs)
-  end
+    defp render_label(form, field, {:safe, _} = label),
+      do: safe_render_label(form, field, label, [])
 
-  defp tag(tag, content, attrs) do
-    Tag.content_tag(tag, content, attrs)
-  end
+    defp render_label(form, field, {label, opts}),
+      do: safe_render_label(form, field, label, opts)
 
-  defp translated_input_id(form, field, locale) do
-    "#{Form.input_id(form, field)}_#{locale}"
-  end
+    defp render_label(form, field, label),
+      do: safe_render_label(form, field, label, [])
 
-  defp translated_input_name(form, field, locale) do
-    "#{Form.input_name(form, field)}[#{locale}]"
-  end
+    defp safe_render_label(form, field, label, opts) do
+      Form.label form, field, opts do
+        label
+      end
+    end
 
-  defp translated_label_for(field, locale) do
-    "#{field}_#{locale}"
+    defp tag(:input = tag, content, attrs) do
+      attrs = Keyword.put_new(attrs, :value, content)
+
+      Tag.tag(tag, attrs)
+    end
+
+    defp tag(tag, content, attrs) do
+      Tag.content_tag(tag, content, attrs)
+    end
+
+    defp translated_input_id(form, field, locale) do
+      "#{Form.input_id(form, field)}_#{locale}"
+    end
+
+    defp translated_input_name(form, field, locale) do
+      "#{Form.input_name(form, field)}[#{locale}]"
+    end
+
+    defp translated_label_for(field, locale) do
+      "#{field}_#{locale}"
+    end
   end
 end

--- a/lib/plugs/put_locale.ex
+++ b/lib/plugs/put_locale.ex
@@ -1,29 +1,31 @@
-defmodule I18nHelpers.Plugs.PutLocale do
-  @moduledoc false
+if Code.ensure_loaded?(Plug) do
+  defmodule I18nHelpers.Plugs.PutLocale do
+    @moduledoc false
 
-  import Plug.Conn
+    import Plug.Conn
 
-  @spec init(keyword) :: keyword
-  def init(options) do
-    Keyword.get(options, :find_locale) ||
-      raise ArgumentError, "must supply `find_locale` option"
+    @spec init(keyword) :: keyword
+    def init(options) do
+      Keyword.get(options, :find_locale) ||
+        raise ArgumentError, "must supply `find_locale` option"
 
-    options
-  end
+      options
+    end
 
-  @spec call(Plug.Conn.t(), keyword) :: Plug.Conn.t()
-  def call(conn, options) do
-    find_locale = Keyword.fetch!(options, :find_locale)
-    backend = Keyword.get(options, :backend)
+    @spec call(Plug.Conn.t(), keyword) :: Plug.Conn.t()
+    def call(conn, options) do
+      find_locale = Keyword.fetch!(options, :find_locale)
+      backend = Keyword.get(options, :backend)
 
-    locale =
-      find_locale.(conn) ||
-        raise "locale not found in conn #{inspect(conn)}"
+      locale =
+        find_locale.(conn) ||
+          raise "locale not found in conn #{inspect(conn)}"
 
-    if backend,
-      do: Gettext.put_locale(backend, locale),
-      else: Gettext.put_locale(locale)
+      if backend,
+        do: Gettext.put_locale(backend, locale),
+        else: Gettext.put_locale(locale)
 
-    assign(conn, :locale, locale)
+      assign(conn, :locale, locale)
+    end
   end
 end

--- a/lib/plugs/put_locale_from_conn.ex
+++ b/lib/plugs/put_locale_from_conn.ex
@@ -1,75 +1,77 @@
-defmodule I18nHelpers.Plugs.PutLocaleFromConn do
-  @moduledoc false
+if Code.ensure_loaded?(Plug) do
+  defmodule I18nHelpers.Plugs.PutLocaleFromConn do
+    @moduledoc false
 
-  import Plug.Conn
+    import Plug.Conn
 
-  @spec init(keyword) :: keyword
-  def init(options) do
-    allowed_locales =
-      Keyword.get(options, :allowed_locales)
-      |> maybe_to_string()
+    @spec init(keyword) :: keyword
+    def init(options) do
+      allowed_locales =
+        Keyword.get(options, :allowed_locales)
+        |> maybe_to_string()
 
-    default_locale =
-      Keyword.get(options, :default_locale)
-      |> maybe_to_string()
+      default_locale =
+        Keyword.get(options, :default_locale)
+        |> maybe_to_string()
 
-    cond do
-      allowed_locales == nil ->
-        options
+      cond do
+        allowed_locales == nil ->
+          options
 
-      default_locale == nil ->
-        options
+        default_locale == nil ->
+          options
 
-      true ->
-        Enum.member?(allowed_locales, default_locale) ||
-          raise ArgumentError, "`default_locale` is not included in `allowed_locales` option"
+        true ->
+          Enum.member?(allowed_locales, default_locale) ||
+            raise ArgumentError, "`default_locale` is not included in `allowed_locales` option"
 
-        options
+          options
+      end
     end
-  end
 
-  @spec get_allowed_locale_or_default(String.t() | nil, list | nil, String.t() | nil) ::
-          String.t() | nil
-  defp get_allowed_locale_or_default(nil, _allowed_locales, default_locale), do: default_locale
+    @spec get_allowed_locale_or_default(String.t() | nil, list | nil, String.t() | nil) ::
+            String.t() | nil
+    defp get_allowed_locale_or_default(nil, _allowed_locales, default_locale), do: default_locale
 
-  defp get_allowed_locale_or_default(locale, nil, default_locale) do
-    cond do
-      byte_size(locale) == 2 -> locale
-      String.match?(locale, ~r/[\w]{2}[-_][\w]{2}/) -> locale
-      true -> default_locale
+    defp get_allowed_locale_or_default(locale, nil, default_locale) do
+      cond do
+        byte_size(locale) == 2 -> locale
+        String.match?(locale, ~r/[\w]{2}[-_][\w]{2}/) -> locale
+        true -> default_locale
+      end
     end
-  end
 
-  defp get_allowed_locale_or_default(locale, allowed_locales, default_locale) do
-    cond do
-      Enum.member?(allowed_locales, locale) -> locale
-      true -> default_locale
+    defp get_allowed_locale_or_default(locale, allowed_locales, default_locale) do
+      cond do
+        Enum.member?(allowed_locales, locale) -> locale
+        true -> default_locale
+      end
     end
+
+    @spec call(Plug.Conn.t(), keyword) :: Plug.Conn.t()
+    def call(conn, options) do
+      find_locale = Keyword.fetch!(options, :find_locale)
+      handle_missing_locale = Keyword.fetch!(options, :handle_missing_locale)
+      allowed_locales = Keyword.get(options, :allowed_locales) |> maybe_to_string()
+      default_locale = Keyword.get(options, :default_locale) |> maybe_to_string()
+      backend = Keyword.get(options, :backend)
+
+      locale =
+        get_allowed_locale_or_default(find_locale.(conn), allowed_locales, default_locale) ||
+          handle_missing_locale.(conn)
+
+      if backend,
+        do: Gettext.put_locale(backend, locale),
+        else: Gettext.put_locale(locale)
+
+      assign(conn, :locale, locale)
+    end
+
+    defp maybe_to_string(nil), do: nil
+
+    defp maybe_to_string(locale_list) when is_list(locale_list),
+      do: Enum.map(locale_list, &to_string/1)
+
+    defp maybe_to_string(locale), do: to_string(locale)
   end
-
-  @spec call(Plug.Conn.t(), keyword) :: Plug.Conn.t()
-  def call(conn, options) do
-    find_locale = Keyword.fetch!(options, :find_locale)
-    handle_missing_locale = Keyword.fetch!(options, :handle_missing_locale)
-    allowed_locales = Keyword.get(options, :allowed_locales) |> maybe_to_string()
-    default_locale = Keyword.get(options, :default_locale) |> maybe_to_string()
-    backend = Keyword.get(options, :backend)
-
-    locale =
-      get_allowed_locale_or_default(find_locale.(conn), allowed_locales, default_locale) ||
-        handle_missing_locale.(conn)
-
-    if backend,
-      do: Gettext.put_locale(backend, locale),
-      else: Gettext.put_locale(locale)
-
-    assign(conn, :locale, locale)
-  end
-
-  defp maybe_to_string(nil), do: nil
-
-  defp maybe_to_string(locale_list) when is_list(locale_list),
-    do: Enum.map(locale_list, &to_string/1)
-
-  defp maybe_to_string(locale), do: to_string(locale)
 end

--- a/lib/plugs/put_locale_from_domain.ex
+++ b/lib/plugs/put_locale_from_domain.ex
@@ -1,65 +1,67 @@
-defmodule I18nHelpers.Plugs.PutLocaleFromDomain do
-  @moduledoc """
-  Plug to fetch the locale from the URL's subdomain;
-  assigns the locale to the Connection and sets the Gettext locale.
+if Code.ensure_loaded?(Plug) do
+  defmodule I18nHelpers.Plugs.PutLocaleFromDomain do
+    @moduledoc """
+    Plug to fetch the locale from the URL's subdomain;
+    assigns the locale to the Connection and sets the Gettext locale.
 
-  This plug is useful if you have URLs similar to:
+    This plug is useful if you have URLs similar to:
 
-      https://mon-super-site.example/bonjour
-      https://mijn-geweldige-website.example/hallo
-      https://mi-gran-sitio.example/hola
-      https://my-awesome-website.example/hello
+        https://mon-super-site.example/bonjour
+        https://mijn-geweldige-website.example/hallo
+        https://mi-gran-sitio.example/hola
+        https://my-awesome-website.example/hello
 
-  ## Options
+    ## Options
 
-    * `:domains_locales_map` - map where each key represents a domain and each
-    value contains the locale to be used for that domain
-    * `:default_locale` - locale to be used if no locale was found in the URL
-    * `:allowed_locales` - a list of allowed locales. If no locale was found,
-    use the `:default locale` if specified, otherwise raise an error.
+      * `:domains_locales_map` - map where each key represents a domain and each
+      value contains the locale to be used for that domain
+      * `:default_locale` - locale to be used if no locale was found in the URL
+      * `:allowed_locales` - a list of allowed locales. If no locale was found,
+      use the `:default locale` if specified, otherwise raise an error.
 
-  `:domains_locales_map` is a mandatory option. Below is an example of a map
-  it can hold:
+    `:domains_locales_map` is a mandatory option. Below is an example of a map
+    it can hold:
 
-      %{
-        "mon-super-site.example" => "fr",
-        "mijn-geweldige-website.example" => "nl",
-        "mi-gran-sitio.example" => "es",
-        "my-awesome-website.example" => "en"
-      }
+        %{
+          "mon-super-site.example" => "fr",
+          "mijn-geweldige-website.example" => "nl",
+          "mi-gran-sitio.example" => "es",
+          "my-awesome-website.example" => "en"
+        }
 
-  """
+    """
 
-  alias I18nHelpers.Plugs.PutLocaleFromConn
+    alias I18nHelpers.Plugs.PutLocaleFromConn
 
-  @spec init(keyword) :: keyword
-  def init(options) do
-    domains_locales_map =
-      Keyword.get(options, :domains_locales_map) ||
-        raise ArgumentError, "must supply `domains_locales_map` option"
+    @spec init(keyword) :: keyword
+    def init(options) do
+      domains_locales_map =
+        Keyword.get(options, :domains_locales_map) ||
+          raise ArgumentError, "must supply `domains_locales_map` option"
 
-    options =
-      Keyword.put(options, :find_locale, fn conn ->
-        Enum.find_value(domains_locales_map, fn {domain, locale} ->
-          locale = to_string(locale)
+      options =
+        Keyword.put(options, :find_locale, fn conn ->
+          Enum.find_value(domains_locales_map, fn {domain, locale} ->
+            locale = to_string(locale)
 
-          cond do
-            String.contains?(conn.host, domain) -> locale
-            true -> nil
-          end
+            cond do
+              String.contains?(conn.host, domain) -> locale
+              true -> nil
+            end
+          end)
         end)
-      end)
 
-    options =
-      Keyword.put(options, :handle_missing_locale, fn conn ->
-        raise "locale not found in host #{conn.host}"
-      end)
+      options =
+        Keyword.put(options, :handle_missing_locale, fn conn ->
+          raise "locale not found in host #{conn.host}"
+        end)
 
-    PutLocaleFromConn.init(options)
-  end
+      PutLocaleFromConn.init(options)
+    end
 
-  @spec call(Plug.Conn.t(), keyword) :: Plug.Conn.t()
-  def call(conn, options) do
-    PutLocaleFromConn.call(conn, options)
+    @spec call(Plug.Conn.t(), keyword) :: Plug.Conn.t()
+    def call(conn, options) do
+      PutLocaleFromConn.call(conn, options)
+    end
   end
 end

--- a/lib/plugs/put_locale_from_path.ex
+++ b/lib/plugs/put_locale_from_path.ex
@@ -1,42 +1,44 @@
-defmodule I18nHelpers.Plugs.PutLocaleFromPath do
-  @moduledoc """
-  Plug to fetch the locale from the first segment of the URL's request path;
-  assigns the locale to the Connection and sets the Gettext locale.
+if Code.ensure_loaded?(Plug) do
+  defmodule I18nHelpers.Plugs.PutLocaleFromPath do
+    @moduledoc """
+    Plug to fetch the locale from the first segment of the URL's request path;
+    assigns the locale to the Connection and sets the Gettext locale.
 
-  This plug is useful if you have URLs similar to:
+    This plug is useful if you have URLs similar to:
 
-      https://example.com/fr/bonjour
-      https://example.com/nl/hallo
-      https://example.com/es/hola
-      https://example.com/hello (default locale "en")
+        https://example.com/fr/bonjour
+        https://example.com/nl/hallo
+        https://example.com/es/hola
+        https://example.com/hello (default locale "en")
 
-  ## Options
+    ## Options
 
-    * `:default_locale` - locale to be used if no locale was found in the URL
-    * `:allowed_locales` - a list of allowed locales. If no locale was found,
-    use the `:default locale` if specified, otherwise raise an error.
+      * `:default_locale` - locale to be used if no locale was found in the URL
+      * `:allowed_locales` - a list of allowed locales. If no locale was found,
+      use the `:default locale` if specified, otherwise raise an error.
 
-  """
+    """
 
-  alias I18nHelpers.Plugs.PutLocaleFromConn
+    alias I18nHelpers.Plugs.PutLocaleFromConn
 
-  @spec init(keyword) :: keyword
-  def init(options) do
-    options =
-      Keyword.put(options, :find_locale, fn conn ->
-        List.first(conn.path_info)
-      end)
+    @spec init(keyword) :: keyword
+    def init(options) do
+      options =
+        Keyword.put(options, :find_locale, fn conn ->
+          List.first(conn.path_info)
+        end)
 
-    options =
-      Keyword.put(options, :handle_missing_locale, fn conn ->
-        raise "locale not found in path #{conn.request_path}"
-      end)
+      options =
+        Keyword.put(options, :handle_missing_locale, fn conn ->
+          raise "locale not found in path #{conn.request_path}"
+        end)
 
-    PutLocaleFromConn.init(options)
-  end
+      PutLocaleFromConn.init(options)
+    end
 
-  @spec call(Plug.Conn.t(), keyword) :: Plug.Conn.t()
-  def call(conn, options) do
-    PutLocaleFromConn.call(conn, options)
+    @spec call(Plug.Conn.t(), keyword) :: Plug.Conn.t()
+    def call(conn, options) do
+      PutLocaleFromConn.call(conn, options)
+    end
   end
 end

--- a/lib/plugs/put_locale_from_subdomain.ex
+++ b/lib/plugs/put_locale_from_subdomain.ex
@@ -1,42 +1,44 @@
-defmodule I18nHelpers.Plugs.PutLocaleFromSubdomain do
-  @moduledoc """
-  Plug to fetch the locale from the URL's subdomain;
-  assigns the locale to the Connection and sets the Gettext locale.
+if Code.ensure_loaded?(Plug) do
+  defmodule I18nHelpers.Plugs.PutLocaleFromSubdomain do
+    @moduledoc """
+    Plug to fetch the locale from the URL's subdomain;
+    assigns the locale to the Connection and sets the Gettext locale.
 
-  This plug is useful if you have URLs similar to:
+    This plug is useful if you have URLs similar to:
 
-      https://fr.example.com/bonjour
-      https://nl.example.com/hallo
-      https://es.example.com/hola
-      https://example.com/hello (default locale "en")
+        https://fr.example.com/bonjour
+        https://nl.example.com/hallo
+        https://es.example.com/hola
+        https://example.com/hello (default locale "en")
 
-  ## Options
+    ## Options
 
-    * `:default_locale` - locale to be used if no locale was found in the URL
-    * `:allowed_locales` - a list of allowed locales. If no locale was found,
-    use the `:default locale` if specified, otherwise raise an error.
+      * `:default_locale` - locale to be used if no locale was found in the URL
+      * `:allowed_locales` - a list of allowed locales. If no locale was found,
+      use the `:default locale` if specified, otherwise raise an error.
 
-  """
+    """
 
-  alias I18nHelpers.Plugs.PutLocaleFromConn
+    alias I18nHelpers.Plugs.PutLocaleFromConn
 
-  @spec init(keyword) :: keyword
-  def init(options) do
-    options =
-      Keyword.put(options, :find_locale, fn conn ->
-        List.first(String.split(conn.host, "."))
-      end)
+    @spec init(keyword) :: keyword
+    def init(options) do
+      options =
+        Keyword.put(options, :find_locale, fn conn ->
+          List.first(String.split(conn.host, "."))
+        end)
 
-    options =
-      Keyword.put(options, :handle_missing_locale, fn conn ->
-        raise "locale not found in host #{conn.host}"
-      end)
+      options =
+        Keyword.put(options, :handle_missing_locale, fn conn ->
+          raise "locale not found in host #{conn.host}"
+        end)
 
-    PutLocaleFromConn.init(options)
-  end
+      PutLocaleFromConn.init(options)
+    end
 
-  @spec call(Plug.Conn.t(), keyword) :: Plug.Conn.t()
-  def call(conn, options) do
-    PutLocaleFromConn.call(conn, options)
+    @spec call(Plug.Conn.t(), keyword) :: Plug.Conn.t()
+    def call(conn, options) do
+      PutLocaleFromConn.call(conn, options)
+    end
   end
 end


### PR DESCRIPTION
The package implements three different parts, depending respectively on Ecto, Phoenix.HTML and Plug. Those 3 dependencies were listed as optional, but the compilation actually failed (or printed some warnings) if some of them were missing.

This commit adds conditional compilation by wrapping modules belonging to the three parts in

```elixir
if Code.ensure_loaded?(x) do
  ...
end
```

Where `x` is `Ecto`/`Phoenix.HTML`/`Plug`.