### PR TITLE
Add support for missing 3-arity translatable associations

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,8 +1,12 @@
 locals_without_parens = [
   translatable_field: 1,
   translatable_belongs_to: 2,
+  translatable_belongs_to: 3,
   translatable_has_many: 2,
+  translatable_has_many: 3,
   translatable_has_one: 2,
+  translatable_has_one: 3,
+  translatable_many_to_many: 2,
   translatable_many_to_many: 3
 ]
 

--- a/lib/ecto/translatable_fields.ex
+++ b/lib/ecto/translatable_fields.ex
@@ -67,8 +67,12 @@ defmodule I18nHelpers.Ecto.TranslatableFields do
         only: [
           translatable_field: 1,
           translatable_belongs_to: 2,
+          translatable_belongs_to: 3,
           translatable_has_many: 2,
+          translatable_has_many: 3,
           translatable_has_one: 2,
+          translatable_has_one: 3,
+          translatable_many_to_many: 2,
           translatable_many_to_many: 3
         ]
 
@@ -122,9 +126,9 @@ defmodule I18nHelpers.Ecto.TranslatableFields do
 
   The macro will add the given field name into the translatable associations list.
   """
-  defmacro translatable_belongs_to(field_name, module_name) do
+  defmacro translatable_belongs_to(field_name, module_name, opts \\ []) do
     quote do
-      belongs_to(unquote(field_name), unquote(module_name))
+      belongs_to(unquote(field_name), unquote(module_name), unquote(opts))
 
       Module.put_attribute(__MODULE__, :translatable_assocs, unquote(field_name))
     end
@@ -135,9 +139,9 @@ defmodule I18nHelpers.Ecto.TranslatableFields do
 
   The macro will add the given field name into the translatable associations list.
   """
-  defmacro translatable_has_many(field_name, module_name) do
+  defmacro translatable_has_many(field_name, module_name, opts \\ []) do
     quote do
-      has_many(unquote(field_name), unquote(module_name))
+      has_many(unquote(field_name), unquote(module_name), unquote(opts))
 
       Module.put_attribute(__MODULE__, :translatable_assocs, unquote(field_name))
     end
@@ -148,9 +152,9 @@ defmodule I18nHelpers.Ecto.TranslatableFields do
 
   The macro will add the given field name into the translatable associations list.
   """
-  defmacro translatable_has_one(field_name, module_name) do
+  defmacro translatable_has_one(field_name, module_name, opts \\ []) do
     quote do
-      has_one(unquote(field_name), unquote(module_name))
+      has_one(unquote(field_name), unquote(module_name), unquote(opts))
 
       Module.put_attribute(__MODULE__, :translatable_assocs, unquote(field_name))
     end


### PR DESCRIPTION
translatable_belongs_to, translatable_has_many and translatable_has_one did not support passing options to them. Also add the relative formatting exceptions.