### PR TITLE
Allow passing multiple locales to Translator.translate

### DIFF
--- a/lib/ecto/translator.ex
+++ b/lib/ecto/translator.ex
@@ -18,7 +18,7 @@ defmodule I18nHelpers.Ecto.Translator do
 
     4. Repeat step 1. for each associated Ecto struct.
   """
-  @spec translate(list | struct | map, String.t() | atom, keyword) ::
+  @spec translate(list | struct | map, list | String.t() | atom, keyword) ::
           list | struct | String.t()
   def translate(data_structure, locale \\ Gettext.get_locale(), opts \\ [])
 
@@ -84,6 +84,40 @@ defmodule I18nHelpers.Ecto.Translator do
     entity
   end
 
+  defp translate_map(%{} = translations_map, [] = _allowed_locales, opts) do
+    fallback_locale =
+      Keyword.get(opts, :fallback_locale, Gettext.get_locale())
+      |> to_string()
+
+    handle_missing_translation =
+      Keyword.get(opts, :handle_missing_translation, fn _, _ -> true end)
+
+    cond do
+      has_translation?(translations_map, fallback_locale) ->
+        translations_map[fallback_locale]
+
+      true ->
+        handle_missing_translation.(translations_map, fallback_locale)
+        ""
+    end
+  end
+
+  defp translate_map(%{} = translations_map, [locale | rest] = _allowed_locales, opts) do
+    locale = to_string(locale)
+
+    handle_missing_translation =
+      Keyword.get(opts, :handle_missing_translation, fn _, _ -> true end)
+
+    cond do
+      has_translation?(translations_map, locale) ->
+        translations_map[locale]
+
+      true ->
+        handle_missing_translation.(translations_map, locale)
+        translate_map(translations_map, rest, opts)
+    end
+  end
+
   defp translate_map(%{} = translations_map, locale, opts) do
     locale = to_string(locale)
 
@@ -112,16 +146,14 @@ defmodule I18nHelpers.Ecto.Translator do
   @doc ~S"""
   Same as `translate/3` but raises an error if a translation is missing.
   """
-  @spec translate!(list | struct | map, String.t() | atom, keyword) ::
+  @spec translate!(list | struct | map, list | String.t() | atom, keyword) ::
           list | struct | String.t()
   def translate!(data_structure, locale \\ Gettext.get_locale(), opts \\ []) do
     handle_missing_field_translation = fn field, translations_map, locale ->
       Keyword.get(opts, :handle_missing_field_translation, fn _, _, _ -> true end)
       |> apply([field, translations_map, locale])
 
-      raise "translation of field #{inspect(field)} for locale \"#{locale}\" not found in map #{
-              inspect(translations_map)
-            }"
+      raise "translation of field #{inspect(field)} for locale \"#{locale}\" not found in map #{inspect(translations_map)}"
     end
 
     handle_missing_translation = fn translations_map, locale ->

--- a/test/ecto/translator_test.exs
+++ b/test/ecto/translator_test.exs
@@ -90,6 +90,19 @@ defmodule I18nHelpers.Ecto.TranslatorTest do
     assert Translator.translate(%{"en" => "hello", "fr" => "bonjour"}, :fr) == "bonjour"
   end
 
+  test "get translation from map, list of locales" do
+    assert Translator.translate(%{"en" => "hello", "fr" => "bonjour"}) == "hello"
+    assert Translator.translate(%{"en" => "hello", "fr" => "bonjour"}, ["en", "fr"]) == "hello"
+    assert Translator.translate(%{"en" => "hello", "fr" => "bonjour"}, ["fr", "en"]) == "bonjour"
+    assert Translator.translate(%{"en" => "hello", "fr" => "bonjour"}, ["it", "fr"]) == "bonjour"
+    assert Translator.translate(%{"en" => "hello", "fr" => "bonjour"}, [:fr, :en]) == "bonjour"
+    assert Translator.translate(%{"fr" => "bonjour"}, ["it", "nl"]) == ""
+
+    assert Translator.translate(%{"en" => "hello", "fr" => "bonjour"}, ["it", "nl"],
+             fallback_locale: "fr"
+           ) == "bonjour"
+  end
+
   test "get translation from map, given key is missing" do
     assert Translator.translate(%{"en" => "hello"}, "nl") == "hello"
 
@@ -150,6 +163,20 @@ defmodule I18nHelpers.Ecto.TranslatorTest do
 
     assert translated_post.translated_title == "The title"
     assert translated_post.translated_body == "The content"
+  end
+
+  test "translate struct with locale list" do
+    post = %Post{
+      title: %{"en" => "The title", "fr" => "Le titre", "it" => "Il titolo"},
+      body: %{"en" => "The content", "fr" => "Le contenu"}
+    }
+
+    assert post.translated_title == nil
+
+    translated_post = Translator.translate(post, ["it", "fr"])
+
+    assert translated_post.translated_title == "Il titolo"
+    assert translated_post.translated_body == "Le contenu"
   end
 
   test "translate struct with associations" do


### PR DESCRIPTION
This allows to specify multiple preferred locales (e.g. extracting them from the Accept-Language header), with a defined priority (the order of the list). The fallback locale is tried last if no locale matches the ones in the list.